### PR TITLE
Cachear carreras guarani

### DIFF
--- a/lib/helpers/api_guarani.js
+++ b/lib/helpers/api_guarani.js
@@ -1,8 +1,9 @@
-import { compose, prop, sortBy, toLower } from 'ramda';
+import { compose, prop, propEq, sortBy, toLower } from 'ramda';
 import axios from 'axios';
 import { guaraniApiUrl } from '../config/auth';
 import { rollbar } from '../config/rollbar';
 import { conCache } from './cache';
+import { find } from 'ramda';
 
 const makeApi = () => axios.create({ baseURL: guaraniApiUrl });
 
@@ -21,13 +22,8 @@ export const inscripcionesPara = async (dni) => {
 };
 
 export const getCarrera = async (idCarrera) => {
-  try {
-    const response = await makeApi().get(`/carreras/${idCarrera}`);
-    return response.data;
-  } catch (error) {
-    rollbar.error('La API Guaraní no se encuentra operativa', error);
-    throw error;
-  }
+  const carreras = await getCarreras();
+  return find(propEq('id', idCarrera), carreras);
 };
 
 export const getCarreras = conCache('carrerasGuarani', async () => {

--- a/lib/helpers/api_guarani.js
+++ b/lib/helpers/api_guarani.js
@@ -1,9 +1,10 @@
 import { compose, prop, sortBy, toLower } from 'ramda';
-
+import NodeCache from 'node-cache';
 import axios from 'axios';
 import { guaraniApiUrl } from '../config/auth';
 import { rollbar } from '../config/rollbar';
 
+const cache = new NodeCache();
 const makeApi = () => axios.create({ baseURL: guaraniApiUrl });
 
 export const inscripcionesPara = async (dni) => {
@@ -30,13 +31,22 @@ export const getCarrera = async (idCarrera) => {
   }
 };
 
+const CARRERAS_CACHE_KEY = 'carrerasGuarani';
 export const getCarreras = async () => {
   try {
+    const desdeCache = cache.get(CARRERAS_CACHE_KEY);
+
+    if (desdeCache) {
+      return desdeCache;
+    }
+
     const response = await makeApi().get(`/carreras`);
     const carrerasOrdenadas = sortBy(
       compose(toLower, prop('nombre')),
       response.data
     );
+
+    cache.set(CARRERAS_CACHE_KEY, carrerasOrdenadas);
 
     return carrerasOrdenadas;
   } catch (error) {

--- a/lib/helpers/api_guarani.js
+++ b/lib/helpers/api_guarani.js
@@ -1,10 +1,9 @@
 import { compose, prop, sortBy, toLower } from 'ramda';
-import NodeCache from 'node-cache';
 import axios from 'axios';
 import { guaraniApiUrl } from '../config/auth';
 import { rollbar } from '../config/rollbar';
+import { conCache } from './cache';
 
-const cache = new NodeCache();
 const makeApi = () => axios.create({ baseURL: guaraniApiUrl });
 
 export const inscripcionesPara = async (dni) => {
@@ -31,26 +30,12 @@ export const getCarrera = async (idCarrera) => {
   }
 };
 
-const CARRERAS_CACHE_KEY = 'carrerasGuarani';
-export const getCarreras = async () => {
+export const getCarreras = conCache('carrerasGuarani', async () => {
   try {
-    const desdeCache = cache.get(CARRERAS_CACHE_KEY);
-
-    if (desdeCache) {
-      return desdeCache;
-    }
-
     const response = await makeApi().get(`/carreras`);
-    const carrerasOrdenadas = sortBy(
-      compose(toLower, prop('nombre')),
-      response.data
-    );
-
-    cache.set(CARRERAS_CACHE_KEY, carrerasOrdenadas);
-
-    return carrerasOrdenadas;
+    return sortBy(compose(toLower, prop('nombre')), response.data);
   } catch (error) {
     rollbar.error('La API Guaraní está en el horno', error);
     throw error;
   }
-};
+});

--- a/lib/helpers/api_guarani.test.js
+++ b/lib/helpers/api_guarani.test.js
@@ -106,89 +106,82 @@ describe('API Guaraní', () => {
     });
   });
 
-  describe('getCarrera', () => {
-    describe('cuando existe la carrera', () => {
-      it('devuelve la carrera', async () => {
-        apiMock.get.mockResolvedValue({
-          data: {
-            nombre: 'Tecnicatura universitaria en Informática',
-          },
-        });
-
-        const carrera = await getCarrera(21);
-        expect(carrera).toEqual({
-          nombre: 'Tecnicatura universitaria en Informática',
-        });
-      });
-    });
-
-    describe('cuando no existe la carrera', () => {
-      it('devuelve null', async () => {
-        apiMock.get.mockResolvedValue({
-          data: null,
-        });
-
-        const carrera = await getCarrera(25);
-        expect(carrera).toBeNull();
-      });
-    });
-  });
-
-  describe('getCarreras', () => {
+  describe('Carreras', () => {
     beforeEach(() => {
       apiMock.get.mockResolvedValue({
         data: [
           {
+            id: 3,
             nombre: 'CURSO PREPARATORIO DE INGLES',
           },
           {
-            nombre: 'Jornada de Kinesiología',
+            id: 21,
+            nombre: 'Tecnicatura universitaria en Informática',
           },
           {
+            id: 8,
             nombre: 'Enfermería Universitaria',
           },
           {
+            id: 71,
             nombre: 'Curso de Preparacion universitaria',
           },
           {
+            id: 14,
             nombre: 'Especialización en Docencia Universitaria',
           },
         ],
       });
     });
+    describe('getCarrera', () => {
+      it('cuando existe la carrera', async () => {
+        const carrera = await getCarrera(21);
+        expect(carrera).toEqual({
+          id: 21,
+          nombre: 'Tecnicatura universitaria en Informática',
+        });
+      });
 
-    it('devuelve las carreras ordenadas por nombre', async () => {
-      const carreras = await getCarreras();
-      expect(carreras).toEqual([
-        {
-          nombre: 'Curso de Preparacion universitaria',
-        },
-        {
-          nombre: 'CURSO PREPARATORIO DE INGLES',
-        },
-        {
-          nombre: 'Enfermería Universitaria',
-        },
-        {
-          nombre: 'Especialización en Docencia Universitaria',
-        },
-        {
-          nombre: 'Jornada de Kinesiología',
-        },
-      ]);
+      it('cuando no existe la carrera', async () => {
+        const carrera = await getCarrera(25);
+        expect(carrera).toBeUndefined();
+      });
     });
 
-    it('no le vuelve a pegar a la API en llamados sucesivos', async () => {
-      // Reseteamos las llamadas para que no afecten los otros tests.
-      apiMock.get.mockClear();
+    describe('getCarreras', () => {
+      it('devuelve las carreras ordenadas por nombre', async () => {
+        const carreras = await getCarreras();
+        expect(carreras).toMatchObject([
+          {
+            nombre: 'Curso de Preparacion universitaria',
+          },
+          {
+            nombre: 'CURSO PREPARATORIO DE INGLES',
+          },
+          {
+            nombre: 'Enfermería Universitaria',
+          },
+          {
+            nombre: 'Especialización en Docencia Universitaria',
+          },
+          {
+            nombre: 'Tecnicatura universitaria en Informática',
+          },
+        ]);
+      });
 
-      await getCarreras();
-      await getCarreras();
-      await getCarreras();
+      it('no le vuelve a pegar a la API en llamados sucesivos', async () => {
+        // Reseteamos las llamadas para que no afecten los otros tests.
+        apiMock.get.mockClear();
 
-      // Depende cómo se ejecute el test, puede tener 0 o 1 llamado.
-      // Sí, así de horrible es la forma de hacer un expect de "fue llamado a lo sumo". 🤷
-      expect(apiMock.get.mock.calls.length).toBeLessThanOrEqual(1);
+        await getCarreras();
+        await getCarreras();
+        await getCarreras();
+
+        // Depende cómo se ejecute el test, puede tener 0 o 1 llamado.
+        // Sí, así de horrible es la forma de hacer un expect de "fue llamado a lo sumo". 🤷
+        expect(apiMock.get.mock.calls.length).toBeLessThanOrEqual(1);
+      });
     });
   });
 });

--- a/lib/helpers/api_guarani.test.js
+++ b/lib/helpers/api_guarani.test.js
@@ -135,7 +135,7 @@ describe('API Guaraní', () => {
   });
 
   describe('getCarreras', () => {
-    it('devuelve las primeras 10 carreras ordenadas por nombre', async () => {
+    beforeEach(() => {
       apiMock.get.mockResolvedValue({
         data: [
           {
@@ -155,7 +155,9 @@ describe('API Guaraní', () => {
           },
         ],
       });
+    });
 
+    it('devuelve las carreras ordenadas por nombre', async () => {
       const carreras = await getCarreras();
       expect(carreras).toEqual([
         {
@@ -174,6 +176,19 @@ describe('API Guaraní', () => {
           nombre: 'Jornada de Kinesiología',
         },
       ]);
+    });
+
+    it('no le vuelve a pegar a la API en llamados sucesivos', async () => {
+      // Reseteamos las llamadas para que no afecten los otros tests.
+      apiMock.get.mockClear();
+
+      await getCarreras();
+      await getCarreras();
+      await getCarreras();
+
+      // Depende cómo se ejecute el test, puede tener 0 o 1 llamado.
+      // Sí, así de horrible es la forma de hacer un expect de "fue llamado a lo sumo". 🤷
+      expect(apiMock.get.mock.calls.length).toBeLessThanOrEqual(1);
     });
   });
 });

--- a/lib/helpers/cache.js
+++ b/lib/helpers/cache.js
@@ -1,0 +1,16 @@
+import NodeCache from 'node-cache';
+
+const cache = new NodeCache();
+
+export const conCache = (cacheKey, obtenerValor) => async () => {
+  const desdeCache = cache.get(cacheKey);
+
+  if (desdeCache) {
+    return desdeCache;
+  }
+
+  const valor = await obtenerValor();
+  cache.set(cacheKey, valor);
+
+  return valor;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3250,6 +3250,11 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -8746,6 +8751,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
+    },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
+      }
     },
     "node-environment-flags": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "jsonwebtoken": "^8.5.1",
     "luxon": "^1.25.0",
     "morgan": "^1.9.1",
+    "node-cache": "^5.1.2",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",


### PR DESCRIPTION
## :dart: Objetivo

Closes unahur-turnos/planificacion#99

## :memo: Comentarios adicionales

La caché que elegí es medio de juguete, porque guarda los valores en memoria. Como solo hay 42 carreras no es mucho problema, pero si fuera algo más grande habría que pensar otra solución.

Además, cambié el `getCarrera` para que aproveche la caché.

## :stop_sign: Requisitos mínimos para pasar la review

- [x] El código tiene tests que prueban la nueva funcionalidad o que el defecto se corrigió