### PR TITLE
Fix error carreras guarani

### DIFF
--- a/lib/helpers/api_guarani.js
+++ b/lib/helpers/api_guarani.js
@@ -32,6 +32,6 @@ export const getCarreras = conCache('carrerasGuarani', async () => {
     return sortBy(compose(toLower, prop('nombre')), response.data);
   } catch (error) {
     rollbar.error('La API Guaraní está en el horno', error);
-    throw error;
+    return [];
   }
 });

--- a/lib/helpers/api_guarani.js
+++ b/lib/helpers/api_guarani.js
@@ -1,4 +1,4 @@
-import { compose, prop, propEq, sortBy, toLower } from 'ramda';
+import { compose, pathOr, prop, propEq, sortBy, toLower } from 'ramda';
 import axios from 'axios';
 import { guaraniApiUrl } from '../config/auth';
 import { rollbar } from '../config/rollbar';
@@ -6,6 +6,14 @@ import { conCache } from './cache';
 import { find } from 'ramda';
 
 const makeApi = () => axios.create({ baseURL: guaraniApiUrl });
+
+const notificarError = (endpoint, error) => {
+  const statusCode = pathOr('desconocido', ['response', 'data', 'status']);
+  rollbar.error(
+    `Guaraní - falló request a ${endpoint} con error ${statusCode}`,
+    { error }
+  );
+};
 
 export const inscripcionesPara = async (dni) => {
   try {
@@ -15,7 +23,7 @@ export const inscripcionesPara = async (dni) => {
     if (error.response.data.status === 404) {
       return [];
     } else {
-      rollbar.error('La API Guaraní está en el horno', error);
+      notificarError('/inscripciones', error);
       return null;
     }
   }
@@ -31,7 +39,7 @@ export const getCarreras = conCache('carrerasGuarani', async () => {
     const response = await makeApi().get(`/carreras`);
     return sortBy(compose(toLower, prop('nombre')), response.data);
   } catch (error) {
-    rollbar.error('La API Guaraní está en el horno', error);
+    notificarError('/carreras', error);
     return [];
   }
 });

--- a/lib/helpers/api_guarani.test.js
+++ b/lib/helpers/api_guarani.test.js
@@ -1,6 +1,7 @@
 import { getCarrera, getCarreras, inscripcionesPara } from './api_guarani';
 
 import axios from 'axios';
+import { limpiarCache } from './cache';
 
 jest.mock('axios');
 
@@ -108,6 +109,7 @@ describe('API Guaraní', () => {
 
   describe('Carreras', () => {
     beforeEach(() => {
+      limpiarCache();
       apiMock.get.mockResolvedValue({
         data: [
           {
@@ -149,6 +151,37 @@ describe('API Guaraní', () => {
     });
 
     describe('getCarreras', () => {
+      describe('cuando la API falla', () => {
+        let carreras;
+
+        beforeEach(async () => {
+          limpiarCache();
+          apiMock.get.mockRejectedValue({
+            response: { data: { status: 503 } },
+          });
+
+          carreras = await getCarreras();
+        });
+
+        it('devuelve lista vacía', async () => {
+          expect(carreras).toEqual([]);
+        });
+
+        it('no cachea el resultado', async () => {
+          apiMock.get.mockResolvedValue({
+            data: [
+              {
+                id: 3,
+                nombre: 'CURSO PREPARATORIO DE INGLES',
+              },
+            ],
+          });
+
+          const carrerasConApiAndando = await getCarreras();
+          expect(carrerasConApiAndando.length).toEqual(1);
+        });
+      });
+
       it('devuelve las carreras ordenadas por nombre', async () => {
         const carreras = await getCarreras();
         expect(carreras).toMatchObject([

--- a/lib/helpers/cache.js
+++ b/lib/helpers/cache.js
@@ -1,4 +1,5 @@
 import NodeCache from 'node-cache';
+import { isEmpty } from 'ramda';
 
 const cache = new NodeCache();
 
@@ -10,7 +11,12 @@ export const conCache = (cacheKey, obtenerValor) => async () => {
   }
 
   const valor = await obtenerValor();
-  cache.set(cacheKey, valor);
+
+  if (!isEmpty(valor)) {
+    cache.set(cacheKey, valor);
+  }
 
   return valor;
 };
+
+export const limpiarCache = () => cache.flushAll();


### PR DESCRIPTION
## :dart: Objetivo

Que no se rompa el endpoint `/carreras` cuando la API Guaraní no responde. 😃 

## :memo: Comentarios adicionales

Notar que en caso de que no ande no se guarda la caché, para que vuelva a intentarlo más tarde.

## :stop_sign: Requisitos mínimos para pasar la review

- [x] El código tiene tests que prueban la nueva funcionalidad o que el defecto se corrigió